### PR TITLE
BootCDN域名变更为cdn.bootcdn.net

### DIFF
--- a/FastGithub.js
+++ b/FastGithub.js
@@ -10,7 +10,7 @@
 // @include       *://github.com/*
 // @include       *://github*
 // @include       *://hub.fastgit.xyz/*
-// @require       https://cdn.bootcss.com/jquery/3.4.1/jquery.min.js
+// @require       https://cdn.bootcdn.net/ajax/libs/jquery/3.4.1/jquery.min.js
 // @version       1.6.4
 // ==/UserScript==
 


### PR DESCRIPTION
BootCDN域名变更为 cdn.bootcdn.net ，老域名 cdn.bootcss.com 将于 2022 年 3 月 31 日下线。详见[bootcdn](https://www.bootcdn.cn/)。
![image](https://user-images.githubusercontent.com/17940898/164652185-89c02605-23a6-4466-82b6-528718b60cf9.png)
